### PR TITLE
Add scroll-behavior: smooth

### DIFF
--- a/src/VueScrollSnap.vue
+++ b/src/VueScrollSnap.vue
@@ -32,7 +32,7 @@
         scroll-snap-destination: 0 0;
         scroll-snap-type: y mandatory;
         scroll-snap-type: mandatory;
-        scroll-behaviour: smooth;
+        scroll-behavior: smooth;
     }
 
     .scroll-snap-container.horizontal {

--- a/src/VueScrollSnap.vue
+++ b/src/VueScrollSnap.vue
@@ -32,6 +32,7 @@
         scroll-snap-destination: 0 0;
         scroll-snap-type: y mandatory;
         scroll-snap-type: mandatory;
+        scroll-behaviour: smooth;
     }
 
     .scroll-snap-container.horizontal {


### PR DESCRIPTION
This adds support for **smooth** navigation between slides using anchor

Example: use `<a href="#slide-id">` to go to scroll with id `slide-id`

```vue
// Index.vue
<VueScrollSnap :fullscreen="true">
      <section class="item">
         <a href="#slide-2">Go to slide 2</a>
      </section>
      <section class="item">
        <a name="slide-2" />
          Section 2
      </section>
</VueScrollSnap>
```